### PR TITLE
Fix bad advice in cook book (#2308)

### DIFF
--- a/googlemock/docs/cook_book.md
+++ b/googlemock/docs/cook_book.md
@@ -229,7 +229,7 @@ If a mock method has no `EXPECT_CALL` spec but is called, Google Mock
 will print a warning about the "uninteresting call". The rationale is:
 
   * New methods may be added to an interface after a test is written. We shouldn't fail a test just because a method it doesn't know about is called.
-  * However, this may also mean there's a bug in the test, so Google Mock shouldn't be silent either. If the user believes these calls are harmless, they can add an `EXPECT_CALL()` to suppress the warning.
+  * However, this may also mean there's a bug in the test, so Google Mock shouldn't be silent either. (Note that the user should [*not* add an `EXPECT_CALL()`](https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#knowing-when-to-expect) to suppress the warning, even if they think the call is harmless).
 
 However, sometimes you may want to suppress all "uninteresting call"
 warnings, while sometimes you may want the opposite, i.e. to treat all


### PR DESCRIPTION
This line directly contradicts the warning that google mock spits out on unused mock calls:
```
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#knowing-when-to-expect for details.
```
One or the other should be changed, and I believe the advice in this file is incorrect.